### PR TITLE
块级元素除非特殊不要指定width

### DIFF
--- a/src/Button.css
+++ b/src/Button.css
@@ -10,7 +10,6 @@
   outline: none;
   height: 44px;
   line-height: 44px;
-  width: 100%;
   border-radius: 5px;
   font-size: 17px;
 }

--- a/src/Button.styl
+++ b/src/Button.styl
@@ -13,7 +13,6 @@
   outline none
   height 44px
   line-height 44px
-  width 100%
   border-radius 5px
   font-size 17px
 


### PR DESCRIPTION
![unknown](https://cloud.githubusercontent.com/assets/1736244/10038696/b8025128-61fb-11e5-994a-4199d788bde0.jpg)

button外默认是div来做容器，默认会有最长宽度，如果这里指定了`width:100%;`会造成无视周边的`padding`
